### PR TITLE
update Azerbaijan languages

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -151,7 +151,7 @@
             "continent": "AS",
             "capital": "Baku",
             "currency": "AZN",
-            "languages": "az,hy"
+            "languages": "az"
         },
         "BA": {
             "name": "Bosnia and Herzegovina",


### PR DESCRIPTION
in Azerbaijan people in hy (armenian) language is not speaking and it's not the secondary language.