### PR TITLE
Added phone code 383 to Kosovo

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -2785,7 +2785,7 @@
   "XK": {
     "name": "Kosovo",
     "native": "Republika e Kosovës",
-    "phone": "377,381,386",
+    "phone": "377,381,383,386",
     "continent": "EU",
     "capital": "Pristina",
     "currency": "EUR",


### PR DESCRIPTION
ITU has added the phone code +383 for Kosovo as of 2017.

[Presentation of national ITU-T E.164 numbering plan for country code: 383 \(https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000FD0001PDFE.pdf\)](https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000FD0001PDFE.pdf)