### PR TITLE
Adding UK entry to countries

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -2640,6 +2640,17 @@
       "sw"
     ]
   },
+  "UK": {
+    "name": "United Kingdom",
+    "native": "United Kingdom",
+    "phone": "44",
+    "continent": "EU",
+    "capital": "London",
+    "currency": "GBP",
+    "languages": [
+      "en"
+    ]
+  },
   "UM": {
     "name": "U.S. Minor Outlying Islands",
     "native": "United States Minor Outlying Islands",


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/ISO_3166-2:GB

"Though GB is the United Kingdom's ISO 3166-1 alpha-2 code, UK is exceptionally reserved for the United Kingdom on the request of the country. Its main usage is the .uk internet ccTLD."

Working with data from the EU, they're using 'UK' (grr) and after a little research, it appears to be a somewhat legitimate thing.