### PR TITLE
🇧🇪 Update Belgium native name

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -216,7 +216,7 @@
   },
   "BE": {
     "name": "Belgium",
-    "native": "België",
+    "native": "Belgique - België - Belgien",
     "phone": "32",
     "continent": "EU",
     "capital": "Brussels",


### PR DESCRIPTION
3 official languages in Belgium : DE, FR, and NL.
The native name should then the combination of the 3 languages instead of just "België" (NL).

Thanks 🇧🇪 