### PR TITLE
Correct Norwegian languages

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -446,6 +446,10 @@
     "name": "Nauruan",
     "native": "Dorerin Naoero"
   },
+  "nb": {
+    "name": "Norwegian Bokmål",
+    "native": "Norsk bokmål"
+  },
   "nd": {
     "name": "North Ndebele",
     "native": "Sindebele"
@@ -464,11 +468,11 @@
   },
   "nn": {
     "name": "Norwegian Nynorsk",
-    "native": "Norsk (nynorsk)"
+    "native": "Norsk nynorsk"
   },
   "no": {
     "name": "Norwegian",
-    "native": "Norsk (bokmål / riksmål)"
+    "native": "Norsk"
   },
   "nr": {
     "name": "South Ndebele",


### PR DESCRIPTION
Following up from #48, I've added the `nb` language, corrected `no` and changed the `native` names to what is commonly used in software (MacOS, Wikipedia, etc). The native name "riksmål" for `nb` has been removed, as it is not mentioned in the ISO 639-1 standard.

The Norwegian languages should now be correctly represented according to the standard, to the best of my ability.

For consumers of this library:
`no` is a macrolanguage that to my knowledge usually refers to `nb`, as that is the most commonly used language in Norway by far (estimated to be the main language for about 85% of the population according to [Nynorsk Wikipedia](https://nn.wikipedia.org/wiki/Bokmål)).