### PR TITLE
Updated Vatican Country Code to 379

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -2688,7 +2688,7 @@
   "VA": {
     "name": "Vatican City",
     "native": "Vaticano",
-    "phone": "39066,379",
+    "phone": "379",
     "continent": "EU",
     "capital": "Vatican City",
     "currency": "EUR",


### PR DESCRIPTION
The country code was showing 39066,379 for some reason.  Updated to 379 according to this: https://countrycode.org/vatican