### PR TITLE
Proper PHP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.lock
 
 coverage
+.phpunit.cache
 
 composer.phar
 

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,8 @@
           "dist/index.php"
       ]
   },
-  "homepage": "http://annexare.github.io/Countries/"
+  "homepage": "http://annexare.github.io/Countries/",
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
     "issues": "https://github.com/annexare/Countries/issues"
   },
   "require": {},
+  "autoload": {
+      "files": [
+          "dist/index.php"
+      ]
+  },
   "homepage": "http://annexare.github.io/Countries/"
 }

--- a/dist/index.php
+++ b/dist/index.php
@@ -13,7 +13,7 @@ use const JSON_THROW_ON_ERROR;
 
 /**
  * Loads a JSON file relative to the current directory.
- * 
+ *
  * @param string $path
  *
  * @return array
@@ -22,18 +22,18 @@ use const JSON_THROW_ON_ERROR;
  */
 function load(string $path): array
 {
-    static $cache = [];
+  static $cache = [];
 
-    if (isset($cache[$path])) {
-        return $cache[$path];
-    }
+  if (isset($cache[$path])) {
+    return $cache[$path];
+  }
 
-    return $cache[$path] = json_decode(
-        file_get_contents(__DIR__ . '/' . $path),
-        true,
-        512,
-        JSON_THROW_ON_ERROR
-    );
+  return $cache[$path] = json_decode(
+    file_get_contents(__DIR__ . '/' . $path),
+    true,
+    512,
+    JSON_THROW_ON_ERROR
+  );
 }
 
 /**
@@ -44,7 +44,7 @@ function load(string $path): array
  */
 function continents(): array
 {
-    return load('continents.min.json');
+  return load('continents.min.json');
 }
 
 /**
@@ -55,7 +55,7 @@ function continents(): array
  */
 function countries(): array
 {
-    return load('countries.min.json');
+  return load('countries.min.json');
 }
 
 /**
@@ -66,7 +66,7 @@ function countries(): array
  */
 function languages(): array
 {
-    return load('languages.min.json');
+  return load('languages.min.json');
 }
 
 /**
@@ -78,5 +78,5 @@ function languages(): array
  */
 function languagesAll(): array
 {
-    return load('languages.all.min.json');
+  return load('languages.all.min.json');
 }

--- a/dist/index.php
+++ b/dist/index.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Annexare\Countries;
+
+use JsonException;
+
+use function array_map;
+use function file_get_contents;
+use function idn_to_utf8;
+use function json_decode;
+use function ord;
+use function preg_match;
+use function str_split;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Loads a JSON file relative to the current directory.
+ * 
+ * @param string $path
+ *
+ * @return array
+ * @throws JsonException
+ * @internal
+ */
+function load(string $path): array
+{
+    static $cache = [];
+
+    if (isset($cache[$path])) {
+        return $cache[$path];
+    }
+
+    return $cache[$path] = json_decode(
+        file_get_contents(__DIR__ . '/' . $path),
+        true,
+        512,
+        JSON_THROW_ON_ERROR
+    );
+}
+
+/**
+ * Continents, key-value object (key is alpha-2 code).
+ *
+ * @return array
+ * @throws JsonException
+ */
+function continents(): array
+{
+    return load('continents.min.json');
+}
+
+/**
+ * Countries, key-value object (key is alpha-2 code, uppercase).
+ *
+ * @return array
+ * @throws JsonException
+ */
+function countries(): array
+{
+    return load('countries.min.json');
+}
+
+/**
+ * Languages in use only, key-value object (key is alpha-2 code).
+ *
+ * @return array
+ * @throws JsonException
+ */
+function languages(): array
+{
+    return load('languages.min.json');
+}
+
+/**
+ * Languages, key-value object (key is alpha-2 code).
+ * A complete list including not used by Countries list.
+ *
+ * @return array
+ * @throws JsonException
+ */
+function languagesAll(): array
+{
+    return load('languages.all.min.json');
+}
+
+/**
+ * Returns country flag Emoji string.
+ *
+ * @param string $countryCode
+ *
+ * @return string
+ */
+function getEmojiFlag(string $countryCode): string
+{
+    $unicodeBase = 127462 - ord('A');
+    $regex='/^[A-Z]{2}$/';
+
+    if (! preg_match($regex, $countryCode)) {
+        return '';
+    }
+
+    return idn_to_utf8(array_map(
+            fn(string $letter) => $unicodeBase + ord($letter),
+            str_split( $countryCode)
+        )
+    );
+}
+
+/**
+ * TODO: Finish implementation
+ * 
+ * @param string $emoji
+ *
+ * @return string
+ * @internal
+ */
+function getUnicode(string $emoji): string
+{
+    return '';
+}

--- a/dist/index.php
+++ b/dist/index.php
@@ -6,13 +6,8 @@ namespace Annexare\Countries;
 
 use JsonException;
 
-use function array_map;
 use function file_get_contents;
-use function idn_to_utf8;
 use function json_decode;
-use function ord;
-use function preg_match;
-use function str_split;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -84,40 +79,4 @@ function languages(): array
 function languagesAll(): array
 {
     return load('languages.all.min.json');
-}
-
-/**
- * Returns country flag Emoji string.
- *
- * @param string $countryCode
- *
- * @return string
- */
-function getEmojiFlag(string $countryCode): string
-{
-    $unicodeBase = 127462 - ord('A');
-    $regex='/^[A-Z]{2}$/';
-
-    if (! preg_match($regex, $countryCode)) {
-        return '';
-    }
-
-    return idn_to_utf8(array_map(
-            fn(string $letter) => $unicodeBase + ord($letter),
-            str_split( $countryCode)
-        )
-    );
-}
-
-/**
- * TODO: Finish implementation
- * 
- * @param string $emoji
- *
- * @return string
- * @internal
- */
-function getUnicode(string $emoji): string
-{
-    return '';
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+
+  <coverage cacheDirectory=".phpunit.cache/code-coverage"
+            processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">dist</directory>
+    </include>
+  </coverage>
+</phpunit>

--- a/tests/CountriesTest.php
+++ b/tests/CountriesTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+use function Annexare\Countries\continents;
+use function Annexare\Countries\countries;
+use function Annexare\Countries\languages;
+use function Annexare\Countries\languagesAll;
+
+class CountriesTest extends TestCase
+{
+  /**
+   * @throws JsonException
+   * @throws ExpectationFailedException
+   * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+   */
+  public function testCountries(): void
+  {
+    $countries = countries();
+
+    self::assertIsArray($countries);
+    self::assertJsonStringEqualsJsonFile(
+      __DIR__ . '/../dist/countries.min.json',
+      json_encode($countries, JSON_THROW_ON_ERROR)
+    );
+  }
+
+  /**
+   * @throws JsonException
+   * @throws ExpectationFailedException
+   * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+   */
+  public function testContinents(): void
+  {
+    $continents = continents();
+
+    self::assertIsArray($continents);
+    self::assertJsonStringEqualsJsonFile(
+      __DIR__ . '/../dist/continents.min.json',
+      json_encode($continents, JSON_THROW_ON_ERROR)
+    );
+  }
+
+  /**
+   * @throws JsonException
+   * @throws ExpectationFailedException
+   * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+   */
+  public function testLanguages(): void
+  {
+    $languages = languages();
+
+    self::assertIsArray($languages);
+    self::assertJsonStringEqualsJsonFile(
+      __DIR__ . '/../dist/languages.min.json',
+      json_encode($languages, JSON_THROW_ON_ERROR)
+    );
+  }
+
+  /**
+   * @throws JsonException
+   * @throws ExpectationFailedException
+   * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+   */
+  public function testLanguagesAll(): void
+  {
+    $languagesAll = languagesAll();
+
+    self::assertIsArray($languagesAll);
+    self::assertJsonStringEqualsJsonFile(
+      __DIR__ . '/../dist/languages.all.min.json',
+      json_encode($languagesAll, JSON_THROW_ON_ERROR)
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a simple wrapper for PHP applications that basically replicates the JavaScript exports as namespaced, autoloaded functions, that can be easily imported.

## The problem
Using this library in PHP currently requires to load the JSON files from the correct filesystem path inside the vendor directory (Laravel example):
```php
private function getCountries(): array
{
    $raw = file_get_contents(base_path(
        'vendor/annexare/country-list/dist/minimal/countries.en.min.json'
    ));

    return json_decode(
        $raw,
        true,
        512,
        JSON_THROW_ON_ERROR
    );
}
```
This means I have a hard dependency on the folder structure staying _exactly the same_ across releases, and I don't even trust myself enough to maintain something like this correctly all the time.

## Proposed solution
This PR adds a wrapper file, providing all exports from the [JavaScript entry file](./dist/index.js) as functions that can be imported thanks to an autoloader entry in the `composer.json`. To prevent unnecessary disk access, all functions use a super-simple loader that caches the file content for optimal performance.

It can be used like this:
```php
require __DIR__ . '/vendor/autoload.php';

// Function imports
use function Annexare\Countries\continents;
$continents = continents();

// Fully-qualified, namespaced function calls
$countries = \Annexare\Countries\countries();
```

This makes it easy to work with the library, and simultaneously shifts responsibility for the proper file names from consumers to the library.

**A note on the flag emoji helpers:**  
I started recreating the emoji functions in PHP, but that requires more time and testing than I'm willing to bring up currently. You could either leave them out entirely (they are JS-exclusive at the moment, anyway) or finish the implementations. I'm not really convinced they add much value for PHP apps, but who am I to decide this.