### PR TITLE
Change Kazakhstan country code to 7

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -1425,7 +1425,7 @@
   "KZ": {
     "name": "Kazakhstan",
     "native": "Қазақстан",
-    "phone": "76,77",
+    "phone": "7",
     "continent": "AS",
     "capital": "Astana",
     "currency": "KZT",


### PR DESCRIPTION
According to https://countrycode.org/kazakhstan the Kazakhstan country code should be +7 instead of +76/+77

Data changes verified with: https://countrycode.org/kazakhstan
