### PR TITLE
Remove sk from Czech Republic languages

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -875,8 +875,7 @@
       "CZK"
     ],
     "languages": [
-      "cs",
-      "sk"
+      "cs"
     ]
   },
   "DE": {


### PR DESCRIPTION
It is a language widely accepted but it is not a state language according to laws.

Data changes verified with: 
https://en.wikipedia.org/wiki/Demographics_of_the_Czech_Republic#Languages
And Czech law: https://www.psp.cz/sqw/text/orig2.sqw?idd=142632
