### PR TITLE
Add Ascension Island and Tristan da Cunha data

### DIFF
--- a/packages/countries/src/data/countries.2to3.ts
+++ b/packages/countries/src/data/countries.2to3.ts
@@ -1,6 +1,7 @@
 import { TCountryCode } from '../types.ts'
 
 export const countries2to3 = {
+  AC: 'ASC',
   AD: 'AND',
   AE: 'ARE',
   AF: 'AFG',
@@ -214,6 +215,7 @@ export const countries2to3 = {
   SX: 'SXM',
   SY: 'SYR',
   SZ: 'SWZ',
+  TA: 'TAA',
   TC: 'TCA',
   TD: 'TCD',
   TF: 'ATF',

--- a/packages/countries/src/data/countries.3to2.ts
+++ b/packages/countries/src/data/countries.3to2.ts
@@ -1,6 +1,7 @@
 import { TCountryCode } from '../types.ts'
 
 export const countries3to2 = {
+  ASC: 'AC',
   AND: 'AD',
   ARE: 'AE',
   AFG: 'AF',
@@ -214,6 +215,7 @@ export const countries3to2 = {
   SXM: 'SX',
   SYR: 'SY',
   SWZ: 'SZ',
+  TAA: 'TA',
   TCA: 'TC',
   TCD: 'TD',
   ATF: 'TF',

--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -9,6 +9,7 @@ export const countries = {
     capital: 'Georgetown',
     currency: ['SHP'],
     languages: ['en'],
+    partOf: 'GB'
   },
   AD: {
     name: 'Andorra',
@@ -1942,6 +1943,7 @@ export const countries = {
     capital: 'Edinburgh of the Seven Seas',
     currency: ['GBP'],
     languages: ['en'],
+    partOf: 'GB'
   },
   TC: {
     name: 'Turks and Caicos Islands',

--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -1,6 +1,15 @@
 import { ICountry } from '../types.ts'
 
 export const countries = {
+  AC: {
+    name: 'Ascension Island',
+    native: 'Ascension Island',
+    phone: [247],
+    continent: 'AF',
+    capital: 'Georgetown',
+    currency: ['SHP'],
+    languages: ['en'],
+  },
   AD: {
     name: 'Andorra',
     native: 'Andorra',
@@ -1924,6 +1933,15 @@ export const countries = {
     capital: 'Lobamba',
     currency: ['SZL'],
     languages: ['en', 'ss'],
+  },
+  TA: {
+    name: 'Tristan da Cunha',
+    native: 'Tristan da Cunha',
+    phone: [290],
+    continent: 'AF',
+    capital: 'Edinburgh of the Seven Seas',
+    currency: ['GBP'],
+    languages: ['en'],
   },
   TC: {
     name: 'Turks and Caicos Islands',


### PR DESCRIPTION
<!--

  Thanks so much for your PR, your contribution is appreciated! ❤️

  Please check this:
  - unit tests are passing
  - separate changes with commits where necessary
  - when data needs to be changed, only files within `/data/` were modified
  - when there is an update for `package.json`, please also push `package-lock.json` changes
  - no `/dist/` file changes accepted (they are built with every version bump)

 -->

Both of these are overseas territories with their own respective phone calling codes and ISO reserved codes.


Data changes verified with: <!-- Please specify URL(s) of a verified source where data was taken -->

Ascension Island:

- https://en.wikipedia.org/wiki/Ascension_Island
- https://www.iso.org/obp/ui/#iso:code:3166:AC

Tristan da Cunha:

- https://en.wikipedia.org/wiki/Tristan_da_Cunha
- https://www.iso.org/obp/ui/#iso:code:3166:TA