### PR TITLE
feat(data): add ZWG to Zimbabwe currencies

### DIFF
--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -2282,7 +2282,7 @@ export const countries = {
     phone: [263],
     continent: 'AF',
     capital: 'Harare',
-    currency: ['USD', 'ZAR', 'BWP', 'GBP', 'AUD', 'CNY', 'INR', 'JPY'],
+    currency: ['ZWG', 'USD', 'ZAR', 'BWP', 'GBP', 'AUD', 'CNY', 'INR', 'JPY'],
     languages: ['en', 'sn', 'nd'],
   },
 } as const satisfies Record<string, ICountry>


### PR DESCRIPTION
## What

Adds **ZWG** (Zimbabwe Gold, ISO 4217 numeric `924`) to Zimbabwe's `currency` list, as the first/official entry:

```
ZW.currency: ['ZWG', 'USD', 'ZAR', 'BWP', 'GBP', 'AUD', 'CNY', 'INR', 'JPY']
```

## Why

Zimbabwe Gold is Zimbabwe's official currency since **8 April 2024**; the ISO 4217 code was changed from `ZWL` to `ZWG` effective **25 June 2024**, and `ZWL` ceased to be recognised from 1 September 2024. The country still operates a multi-currency regime (USD dominant in practice), so the foreign currencies are kept — but the domestic official currency was missing.

`ZWG` already exists in the currency table (`packages/countries/src/data/currencies.ts`), so this only links it to the country. Additive, non-breaking.

## Refs

- RBZ — Introduction of ZiG currency code (ZWG): https://www.rbz.co.zw/documents/press/2024/July/PRESS_STATEMENT_ON_ZiG_CURRENCY_CODE.pdf
- https://en.wikipedia.org/wiki/Zimbabwean_ZiG