### PR TITLE
fix(data): adopt ISO short names — Czechia, Cabo Verde

### DIFF
--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -473,7 +473,7 @@ export const countries = {
     languages: ['es'],
   },
   CV: {
-    name: 'Cape Verde',
+    name: 'Cabo Verde',
     native: 'Cabo Verde',
     phone: [238],
     continent: 'AF',
@@ -509,7 +509,7 @@ export const countries = {
     languages: ['el', 'tr', 'hy'],
   },
   CZ: {
-    name: 'Czech Republic',
+    name: 'Czechia',
     native: 'Česká republika',
     phone: [420],
     continent: 'EU',

--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -510,7 +510,7 @@ export const countries = {
   },
   CZ: {
     name: 'Czechia',
-    native: 'Česká republika',
+    native: 'Česko',
     phone: [420],
     continent: 'EU',
     capital: 'Prague',

--- a/packages/test-js/getCountryCode.test.ts
+++ b/packages/test-js/getCountryCode.test.ts
@@ -23,3 +23,14 @@ test('getCountryCode()', () => {
   expect(getCountryCode('Myanmar (Burma)')).toBe('MM')
   expect(getCountryCode('Cocos (Keeling) Islands')).toBe('CC')
 })
+
+test('getCountryCode() resolves ISO short names', () => {
+  expect(getCountryCode('Czechia')).toBe('CZ')
+  expect(getCountryCode('Česko')).toBe('CZ')
+  expect(getCountryCode('Cabo Verde')).toBe('CV')
+
+  // Previous long-form names are no longer resolvable
+  expect(getCountryCode('Czech Republic')).toBe(false)
+  expect(getCountryCode('Česká republika')).toBe(false)
+  expect(getCountryCode('Cape Verde')).toBe(false)
+})


### PR DESCRIPTION
## What

Updates two countries to their official **ISO 3166 / UN short English names**, and aligns the Czech `native` to its matching short form:

| Code | `name` (before → after) | `native` (before → after) |
|------|--------------------------|----------------------------|
| `CZ` | Czech Republic → **Czechia** | Česká republika → **Česko** |
| `CV` | Cape Verde → **Cabo Verde** | already `Cabo Verde` (no change) |

## Why

Consistency with the short-name policy already applied to **Türkiye**, **Kyiv**, **Eswatini**, and **North Macedonia**. "Czechia" (ISO/UN since 2016) and "Cabo Verde" (ISO/UN since 2013) are the current official English short names.

ISO 3166 defines names only in **English and French** — it has no native-language field — so `native` is the dataset's own field. `Česko` is the official Czech **short** form (the native equivalent of "Czechia"), chosen to match the short English `name` and the dataset's short-native convention (e.g. Germany/`Deutschland`). `CV` native was already the short, untranslated `Cabo Verde`.

## ⚠️ Behavior change (reverse name lookup)

`getCountryCode()` matches on `name`/`native`, so the old strings no longer resolve:

```ts
getCountryCode('Czech Republic')   // false (was 'CZ')
getCountryCode('Česká republika')  // false (was 'CZ')
getCountryCode('Cape Verde')       // false (was 'CV')

getCountryCode('Czechia')          // 'CZ'
getCountryCode('Česko')            // 'CZ'
getCountryCode('Cabo Verde')       // 'CV'
```

Worth a changelog note. Shipping in the same minor as the currency data updates.

## Sources

Official **ISO 3166 / UN** short names — not arbitrary edits, and consistent with names the dataset already uses for the same reason (e.g. Türkiye per ISO 3166).

**CZ → "Czechia" / "Česko"** — "Czechia" registered in UN UNTERM/UNGEGN (5 Jul 2016) and added to ISO 3166 (Sep 2016), alongside the formal "the Czech Republic". ISO carries only the English/French name; the UN recognises **Česko** (short) / Česká republika (formal) as the Czech names:
- [UN UNGEGN country record](https://ungegn.un.org/dashboard/countries/details?id=203) — English short **Czechia**, formal **the Czech Republic**
- [ISO 3166 OBP — CZ](https://www.iso.org/obp/ui/#iso:code:3166:CZ) (English short `Czechia`; no native field)
- [Czech MFA — "Czechia"/"Česko"](https://mzv.gov.cz/jnp/en/issues_and_press/factsheets/x2016_04_21_the_completion_of_translations_of_the.html)

**CV → "Cabo Verde"** — the Republic of Cabo Verde asked the UN (24 Oct 2013) to use "Cabo Verde" in all official languages, untranslated; ISO 3166 follows UN usage:
- [UN member-state page — "Cabo Verde"](https://www.un.org/en/about-us/member-states/cabo-verde)
- [ISO 3166 OBP — CV](https://www.iso.org/obp/ui/#iso:code:3166:CV)
