### PR TITLE
test(currencies): cover built dist subpath bundle

### DIFF
--- a/packages/test-js/dist-currencies.test.ts
+++ b/packages/test-js/dist-currencies.test.ts
@@ -1,0 +1,37 @@
+// biome-ignore-all lint/performance/noDynamicNamespaceImportAccess: test file
+
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// @ts-expect-error — built artifact, no types resolved at this path
+import * as distCurrencies from '../../dist/mjs/currencies.js'
+import * as source from '../countries/src/currencies.ts'
+
+const distDir = path.resolve(import.meta.dir, '../../dist')
+
+describe('dist currencies subpath', () => {
+  test('built ESM bundle re-exports the public currencies API', () => {
+    for (const name of ['currencies', 'getCurrency', 'getCurrencyByNumeric'] as const) {
+      expect(Object.hasOwn(distCurrencies, name)).toBe(true)
+    }
+  })
+
+  test('built bundle currency keys match source', () => {
+    expect(Object.keys(distCurrencies.currencies)).toEqual(Object.keys(source.currencies))
+  })
+
+  test('getCurrency / getCurrencyByNumeric resolve from the built bundle', () => {
+    expect(distCurrencies.getCurrency('UAH').numeric).toBe('980')
+    expect(distCurrencies.getCurrencyByNumeric('840')?.code).toBe('USD')
+  })
+
+  test('currency dataset is kept out of the main bundle (opt-in only)', () => {
+    // `symbolNative` exists only on currency records; finding it in the default
+    // bundle would mean the currencies dataset leaked in and inflated its size.
+    for (const file of ['index.iife.js', 'mjs/index.js', 'cjs/index.js']) {
+      const bundle = fs.readFileSync(path.join(distDir, file), { encoding: 'utf-8' })
+      expect(bundle.includes('symbolNative')).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## What

Adds `packages/test-js/dist-currencies.test.ts`, exercising the **built** `countries-list/currencies` subpath bundle (`dist/mjs/currencies.js`) — which previously shipped with no test at the dist level (the existing `index.test.ts` only covers the main bundle).

Asserts:
- the built ESM bundle re-exports `currencies`, `getCurrency`, `getCurrencyByNumeric`
- its currency keys match the source module
- `getCurrency` / `getCurrencyByNumeric` resolve correctly from the built artifact
- the currency dataset stays **out** of the main/IIFE/CJS bundles (guards the opt-in split against accidental bundle-size regressions)

## Why

The currencies subpath is a new public entry point; this locks in that the published artifact actually works and stays separated from the default bundle. Runs after `bun run build` (the `test` script builds first), so the dist artifacts exist in CI.