### PR TITLE
test(node): restore test-node as a real Node-runtime suite

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,6 +12,7 @@ on:
       - 'packages/countries/**'
       - 'packages/scripts/**'
       - 'packages/test-js/**'
+      - 'packages/test-node/**'
       - 'packages/tsconfig/**'
       - 'package.json'
       - 'bun.lock'
@@ -39,5 +40,34 @@ jobs:
 
       - name: Build & Test
         run: bun run ci
+        env:
+          CI: true
+
+  test-node:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build dist
+        run: bun run build
+
+      # Run directly with `node` (not `bun run`, which `bunfig [run] bun=true`
+      # would re-route to Bun) to validate the published bundles under Node.js.
+      - name: Test dist under Node.js
+        run: node --test packages/test-node/*.test.ts
         env:
           CI: true

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,9 @@
         "typescript": "catalog:default",
       },
     },
+    "packages/test-node": {
+      "name": "test-node",
+    },
     "packages/tsconfig": {
       "name": "tsconfig",
       "version": "1.0.0",
@@ -353,6 +356,8 @@
     "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
 
     "test-js": ["test-js@workspace:packages/test-js"],
+
+    "test-node": ["test-node@workspace:packages/test-node"],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 

--- a/packages/test-node/index.test.ts
+++ b/packages/test-node/index.test.ts
@@ -1,73 +1,55 @@
 // biome-ignore-all lint/performance/noDynamicNamespaceImportAccess: test file
 
-import { describe, expect, test } from 'bun:test'
-import fs from 'node:fs'
-import path from 'node:path'
+// Validates the published bundles under the real Node.js runtime (CommonJS + ESM
+// loaders), which the Bun-run test-js suite does not exercise. Imports only built
+// dist artifacts — never the TS source — so it mirrors what a Node consumer resolves.
 
-import * as mjs from '../../dist/mjs/index.js'
-import * as source from '../countries/src/index.ts'
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { describe, test } from 'node:test'
 
-const distDir = path.resolve(import.meta.dir, '../../dist')
+const require = createRequire(import.meta.url)
 
-const exportDataList: Partial<keyof typeof source>[] = ['continents', 'countries', 'languages']
-const exportFnList: Partial<keyof typeof source>[] = ['getEmojiFlag']
+const expectedFns = ['getCountryCode', 'getCountryData', 'getCountryDataList', 'getEmojiFlag']
+const expectedData = ['continents', 'countries', 'languages']
 
-function evalIIFE(name = 'Countries') {
-  const script = fs.readFileSync(path.join(distDir, 'index.iife.js'), { encoding: 'utf-8' })
-  // biome-ignore lint/security/noGlobalEval: -
-  eval(`this.${name} = (function () { ${script}\nreturn ${name}})()`)
-}
+describe('dist under Node.js', () => {
+  test('CJS main bundle loads via require()', () => {
+    const cjs = require('../../dist/cjs/index.js')
 
-describe('dist', () => {
-  test('has proper CJS ES6 export', () => {
-    expect(typeof mjs).toBe('object')
-
-    for (const prop of exportFnList) {
-      expect(Object.hasOwn(mjs, prop)).toBe(true)
+    for (const fn of expectedFns) {
+      assert.equal(typeof cjs[fn], 'function', `missing function: ${fn}`)
     }
-
-    for (const prop of exportDataList) {
-      expect(Object.hasOwn(mjs, prop)).toBe(true)
-
-      const cjsKeys = Object.keys(mjs[prop])
-      const srcKeys = Object.keys(source[prop])
-      expect(cjsKeys).toEqual(srcKeys)
+    for (const key of expectedData) {
+      assert.equal(typeof cjs[key], 'object', `missing data: ${key}`)
     }
+    assert.equal(cjs.getEmojiFlag('UA'), '🇺🇦')
   })
 
-  test('all English country names should contain only A-Z characters', () => {
-    const nameReg = /^[a-z\s.()-]+$/i
-    const nonAZ: string[] = []
-    for (const c of Object.values(source.countries)) {
-      if (!nameReg.test(c.name)) {
-        nonAZ.push(c.name)
-      }
-    }
+  test('ESM main bundle loads via import()', async () => {
+    const mjs = await import('../../dist/mjs/index.js')
 
-    // It helps see incorrect names right away in logs
-    expect(nonAZ).toEqual([])
+    for (const fn of expectedFns) {
+      assert.equal(typeof mjs[fn], 'function', `missing function: ${fn}`)
+    }
+    for (const key of expectedData) {
+      assert.equal(typeof mjs[key], 'object', `missing data: ${key}`)
+    }
+    assert.equal(mjs.getEmojiFlag('UA'), '🇺🇦')
   })
 
-  test('loads ES6 <script> properly', () => {
-    const context: { Countries?: typeof source } = {}
-    evalIIFE.call(context)
+  test('CJS currencies subpath loads via require()', () => {
+    const cjs = require('../../dist/cjs/currencies.js')
 
-    const contextCountries = context.Countries
+    assert.equal(typeof cjs.getCurrency, 'function')
+    assert.equal(typeof cjs.getCurrencyByNumeric, 'function')
+    assert.equal(cjs.getCurrency('UAH').numeric, '980')
+  })
 
-    expect(contextCountries).toBeTruthy()
-    expect(contextCountries).toBeObject()
+  test('ESM currencies subpath loads via import()', async () => {
+    const mjs = await import('../../dist/mjs/currencies.js')
 
-    for (const prop of exportFnList) {
-      expect(contextCountries).toHaveProperty(prop)
-    }
-
-    for (const prop of exportDataList) {
-      expect(contextCountries).toHaveProperty(prop)
-
-      // biome-ignore lint/style/noNonNullAssertion: -
-      const windowProps = Object.keys(contextCountries![prop]) as string[]
-      const dataProps = Object.keys(source[prop]) as string[]
-      expect(windowProps).toEqual(dataProps)
-    }
+    assert.equal(typeof mjs.getCurrency, 'function')
+    assert.equal(mjs.getCurrencyByNumeric('840')?.code, 'USD')
   })
 })

--- a/packages/test-node/package.json
+++ b/packages/test-node/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-node",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test ./*.test.ts"
+  }
+}


### PR DESCRIPTION
## What

Restores `packages/test-node` as a genuine **Node.js** test of the published bundles, replacing the stray Bun-only file that nothing ran.

- gives `test-node` a `package.json` again (`node --test`, Node's native TS type-stripping — no loader needed)
- rewrites `index.test.ts` to load the **built dist** under Node's real **CJS (`require`)** and **ESM (`import`)** loaders, for both entry points (`.` and `./currencies`) — never the `.ts` source
- adds a dedicated **Node 24** job to `build-test.yml`

## Why

`test-node` was a real Node-runtime package until the Oct-2025 rename to `test-js` moved its `package.json` away, leaving a leftover `index.test.ts` that imported `bun:test` + `.ts` source and was wired into no script or workflow. Bun-only CI doesn't validate that the shipped CJS/ESM bundles actually execute under Node — the runtime most consumers use. This restores that guarantee (and would catch packaging/interop regressions Bun papers over).

## Notes

- The CI step calls `node --test` **directly**, not via `bun run` — `bunfig.toml` `[run] bun = true` re-routes `node` to Bun, which would defeat the purpose.
- Verified locally (Node 26): 4/4 pass — CJS + ESM × main + currencies.
- Added `packages/test-node/**` to the workflow path filter so changes trigger CI.