### PR TITLE
feat: resolve alternative and former country names in getCountryCode

### DIFF
--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -1338,7 +1338,7 @@ export const countries = {
   MM: {
     name: 'Myanmar',
     native: 'မြန်မာ',
-    alias: ['Burma'],
+    alias: ['Burma', 'Myanmar (Burma)'],
     phone: [95],
     continent: 'AS',
     capital: 'Naypyidaw',

--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -23,6 +23,7 @@ export const countries = {
   AE: {
     name: 'United Arab Emirates',
     native: 'دولة الإمارات العربية المتحدة',
+    alias: ['UAE', 'Emirates'],
     phone: [971],
     continent: 'AS',
     capital: 'Abu Dhabi',
@@ -367,6 +368,7 @@ export const countries = {
   CD: {
     name: 'Democratic Republic of the Congo',
     native: 'République démocratique du Congo',
+    alias: ['Zaire', 'Congo-Kinshasa', 'DR Congo', 'DRC'],
     phone: [243],
     continent: 'AF',
     capital: 'Kinshasa',
@@ -385,6 +387,7 @@ export const countries = {
   CG: {
     name: 'Republic of the Congo',
     native: 'République du Congo',
+    alias: ['Congo-Brazzaville'],
     phone: [242],
     continent: 'AF',
     capital: 'Brazzaville',
@@ -475,6 +478,7 @@ export const countries = {
   CV: {
     name: 'Cabo Verde',
     native: 'Cabo Verde',
+    alias: ['Cape Verde'],
     phone: [238],
     continent: 'AF',
     capital: 'Praia',
@@ -511,6 +515,7 @@ export const countries = {
   CZ: {
     name: 'Czechia',
     native: 'Česko',
+    alias: ['Czech Republic', 'Česká republika'],
     phone: [420],
     continent: 'EU',
     capital: 'Prague',
@@ -702,6 +707,7 @@ export const countries = {
   GB: {
     name: 'United Kingdom',
     native: 'United Kingdom',
+    alias: ['UK', 'Britain', 'Great Britain'],
     phone: [44],
     continent: 'EU',
     capital: 'London',
@@ -982,6 +988,7 @@ export const countries = {
   IR: {
     name: 'Iran',
     native: 'ایران',
+    alias: ['Persia'],
     phone: [98],
     continent: 'AS',
     capital: 'Tehran',
@@ -1063,6 +1070,7 @@ export const countries = {
   KH: {
     name: 'Cambodia',
     native: 'កម្ពុជា',
+    alias: ['Kampuchea'],
     phone: [855],
     continent: 'AS',
     capital: 'Phnom Penh',
@@ -1099,6 +1107,7 @@ export const countries = {
   KP: {
     name: 'North Korea',
     native: '북한',
+    alias: ['DPRK'],
     phone: [850],
     continent: 'AS',
     capital: 'Pyongyang',
@@ -1108,6 +1117,7 @@ export const countries = {
   KR: {
     name: 'South Korea',
     native: '대한민국',
+    alias: ['Republic of Korea'],
     phone: [82],
     continent: 'AS',
     capital: 'Seoul',
@@ -1145,6 +1155,7 @@ export const countries = {
   LA: {
     name: 'Laos',
     native: 'ສປປລາວ',
+    alias: ['Lao PDR'],
     phone: [856],
     continent: 'AS',
     capital: 'Vientiane',
@@ -1181,6 +1192,7 @@ export const countries = {
   LK: {
     name: 'Sri Lanka',
     native: 'śrī laṃkāva',
+    alias: ['Ceylon'],
     phone: [94],
     continent: 'AS',
     capital: 'Colombo',
@@ -1307,6 +1319,7 @@ export const countries = {
   MK: {
     name: 'North Macedonia',
     native: 'Северна Македонија',
+    alias: ['Macedonia', 'FYROM'],
     phone: [389],
     continent: 'EU',
     capital: 'Skopje',
@@ -1323,8 +1336,9 @@ export const countries = {
     languages: ['fr'],
   },
   MM: {
-    name: 'Myanmar (Burma)',
+    name: 'Myanmar',
     native: 'မြန်မာ',
+    alias: ['Burma'],
     phone: [95],
     continent: 'AS',
     capital: 'Naypyidaw',
@@ -1505,6 +1519,7 @@ export const countries = {
   NL: {
     name: 'Netherlands',
     native: 'Nederland',
+    alias: ['Holland'],
     phone: [31],
     continent: 'EU',
     capital: 'Amsterdam',
@@ -1730,6 +1745,7 @@ export const countries = {
   RU: {
     name: 'Russia',
     native: 'Россия',
+    alias: ['Russian Federation'],
     phone: [7],
     continent: 'AS',
     continents: ['AS', 'EU'],
@@ -1921,6 +1937,7 @@ export const countries = {
   SY: {
     name: 'Syria',
     native: 'سوريا',
+    alias: ['Syrian Arab Republic'],
     phone: [963],
     continent: 'AS',
     capital: 'Damascus',
@@ -1930,6 +1947,7 @@ export const countries = {
   SZ: {
     name: 'Eswatini',
     native: 'Eswatini',
+    alias: ['Swaziland'],
     phone: [268],
     continent: 'AF',
     capital: 'Lobamba',
@@ -1985,6 +2003,7 @@ export const countries = {
   TH: {
     name: 'Thailand',
     native: 'ประเทศไทย',
+    alias: ['Siam'],
     phone: [66],
     continent: 'AS',
     capital: 'Bangkok',
@@ -2048,6 +2067,7 @@ export const countries = {
   TR: {
     name: 'Türkiye',
     native: 'Türkiye',
+    alias: ['Turkey'],
     phone: [90],
     continent: 'AS',
     continents: ['AS', 'EU'],
@@ -2121,6 +2141,7 @@ export const countries = {
   US: {
     name: 'United States',
     native: 'United States',
+    alias: ['USA', 'America', 'United States of America'],
     phone: [1],
     continent: 'NA',
     capital: 'Washington D.C.',
@@ -2148,6 +2169,7 @@ export const countries = {
   VA: {
     name: 'Vatican City',
     native: 'Vaticano',
+    alias: ['Holy See', 'Vatican'],
     phone: [379],
     continent: 'EU',
     capital: 'Vatican City',
@@ -2193,6 +2215,7 @@ export const countries = {
   VN: {
     name: 'Vietnam',
     native: 'Việt Nam',
+    alias: ['Viet Nam'],
     phone: [84],
     continent: 'AS',
     capital: 'Hanoi',

--- a/packages/countries/src/getCountryCode.ts
+++ b/packages/countries/src/getCountryCode.ts
@@ -14,7 +14,9 @@ export const getCountryCode = (countryName: string): TCountryCode | false => {
   const nameRegex = new RegExp(`^${name}$`, 'i')
 
   return (
-    countryDataList.find(({ name, native }) => nameRegex.test(name) || nameRegex.test(native))
-      ?.iso2 || false
+    countryDataList.find(
+      ({ name, native, alias }) =>
+        nameRegex.test(name) || nameRegex.test(native) || !!alias?.some((a) => nameRegex.test(a))
+    )?.iso2 || false
   )
 }

--- a/packages/countries/src/types.ts
+++ b/packages/countries/src/types.ts
@@ -10,6 +10,11 @@ export type TLanguageCode = keyof typeof languages
 
 export interface ICountry {
   /**
+   * Alternative and former names (previous ISO short names, common short forms),
+   * matched by `getCountryCode` for backward-compatible reverse lookup.
+   */
+  alias?: string[]
+  /**
    * Capital in English.
    */
   capital: string

--- a/packages/test-js/getCountryCode.aliases.test.ts
+++ b/packages/test-js/getCountryCode.aliases.test.ts
@@ -10,6 +10,7 @@ test('getCountryCode() resolves alternative and former names', () => {
   expect(getCountryCode('Swaziland')).toBe('SZ')
   expect(getCountryCode('Macedonia')).toBe('MK')
   expect(getCountryCode('Burma')).toBe('MM')
+  expect(getCountryCode('Myanmar (Burma)')).toBe('MM') // previously the name; kept resolvable
   expect(getCountryCode('Zaire')).toBe('CD')
   expect(getCountryCode('UK')).toBe('GB')
   expect(getCountryCode('America')).toBe('US')

--- a/packages/test-js/getCountryCode.aliases.test.ts
+++ b/packages/test-js/getCountryCode.aliases.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'bun:test'
+
+import { getCountryCode } from '../countries/src/getCountryCode.ts'
+import { getCountryDataList } from '../countries/src/getCountryData.ts'
+import type { TCountryCode } from '../countries/src/types.ts'
+
+test('getCountryCode() resolves alternative and former names', () => {
+  expect(getCountryCode('Turkey')).toBe('TR')
+  expect(getCountryCode('Cape Verde')).toBe('CV')
+  expect(getCountryCode('Swaziland')).toBe('SZ')
+  expect(getCountryCode('Macedonia')).toBe('MK')
+  expect(getCountryCode('Burma')).toBe('MM')
+  expect(getCountryCode('Zaire')).toBe('CD')
+  expect(getCountryCode('UK')).toBe('GB')
+  expect(getCountryCode('America')).toBe('US')
+  expect(getCountryCode('Holland')).toBe('NL')
+  expect(getCountryCode('Persia')).toBe('IR')
+  expect(getCountryCode('Ceylon')).toBe('LK')
+})
+
+test('getCountryCode() alias matching is case-insensitive and trims', () => {
+  expect(getCountryCode('  czech republic ')).toBe('CZ')
+  expect(getCountryCode('BURMA')).toBe('MM')
+})
+
+test('getCountryCode() still returns false for unknown names', () => {
+  expect(getCountryCode('Atlantis')).toBe(false)
+})
+
+test('every alias resolves to its own country', () => {
+  for (const country of getCountryDataList()) {
+    for (const alias of country.alias ?? []) {
+      expect(getCountryCode(alias)).toBe(country.iso2)
+    }
+  }
+})
+
+// Guard against false-positives: no lookup string may resolve to more than one country.
+// Every name, native name and alias must be unambiguous, so a returned code is trusted.
+test('no name, native, or alias is ambiguous across countries', () => {
+  const owners = new Map<string, TCountryCode>()
+  const claim = (value: string, code: TCountryCode, kind: string) => {
+    const key = value.trim().toLowerCase()
+    const existing = owners.get(key)
+    expect(
+      existing === undefined || existing === code,
+      `"${value}" (${kind}) maps to ${existing} and ${code}`
+    ).toBe(true)
+    owners.set(key, code)
+  }
+
+  for (const country of getCountryDataList()) {
+    claim(country.name, country.iso2, 'name')
+    claim(country.native, country.iso2, 'native')
+    for (const alias of country.alias ?? []) claim(alias, country.iso2, 'alias')
+  }
+})

--- a/packages/test-js/getCountryCode.test.ts
+++ b/packages/test-js/getCountryCode.test.ts
@@ -20,7 +20,7 @@ test('getCountryCode()', () => {
   expect(getCountryCode('澳門')).toBe('MO')
 
   // Special symbols
-  expect(getCountryCode('Myanmar (Burma)')).toBe('MM')
+  expect(getCountryCode('Myanmar')).toBe('MM')
   expect(getCountryCode('Cocos (Keeling) Islands')).toBe('CC')
 })
 
@@ -29,8 +29,8 @@ test('getCountryCode() resolves ISO short names', () => {
   expect(getCountryCode('Česko')).toBe('CZ')
   expect(getCountryCode('Cabo Verde')).toBe('CV')
 
-  // Previous long-form names are no longer resolvable
-  expect(getCountryCode('Czech Republic')).toBe(false)
-  expect(getCountryCode('Česká republika')).toBe(false)
-  expect(getCountryCode('Cape Verde')).toBe(false)
+  // Previous long-form names now resolve via aliases
+  expect(getCountryCode('Czech Republic')).toBe('CZ')
+  expect(getCountryCode('Česká republika')).toBe('CZ')
+  expect(getCountryCode('Cape Verde')).toBe('CV')
 })


### PR DESCRIPTION
**Targets 3.4.1** — ships as a patch to fix the 3.4 name→code regression. The historical (ISO 3166-3) + regions sub-modules follow in 3.5.0.

## Problem

ISO alpha-2 codes are stable across renames, but `getCountryCode(name)` breaks when a country adopts a new ISO short name. `getCountryCode('Czech Republic')`, `'Turkey'`, `'Cape Verde'` all returned `false`. This also matters for name-based sources like Discogs ("UK", "USSR"…) and MusicBrainz.

## Approach — inline `alias`, fixes the default lookup

An optional `alias?: string[]` on `ICountry`, matched by the core `getCountryCode`. So the fix applies to **every** consumer of the default function — no opt-in, no separate import.

```ts
getCountryCode('Czech Republic') // 'CZ'
getCountryCode('Turkey')         // 'TR'  (current name is 'Türkiye')
getCountryCode('Burma')          // 'MM'
getCountryCode('UK')             // 'GB'
getCountryData('MM').alias       // ['Burma']
```

_(Earlier drafts used a separate `countries-list/aliases` sub-module. Dropped after measuring: the data is ~0.6 KB, and a sub-module wouldn't fix the **default** `getCountryCode` — only opt-in importers. Inline is simpler and fixes it for everyone.)_

## Scope — curated, 23 countries

- **Recent ISO renames** (the actual backward-compat fix): Czechia←`Czech Republic`, Cabo Verde←`Cape Verde`, Türkiye←`Turkey`, Eswatini←`Swaziland`, North Macedonia←`Macedonia`, Myanmar←`Burma`.
- **Common short forms**: GB←`UK`/`Britain`, US←`USA`/`America`, AE←`UAE`, NL←`Holland`, RU←`Russian Federation`.
- **Former single-country names**: IR←`Persia`, LK←`Ceylon`, TH←`Siam`, KH←`Kampuchea`, CD←`Zaire`.

Also cleans the ad-hoc name hack: `'Myanmar (Burma)'` → name `'Myanmar'` + alias `'Burma'`.

## Safety — false-positives guarded

Matching stays **exact, case-insensitive, trimmed** (no fuzzy/substring), so a returned code is trusted. A **guard test fails the build if any name, native, or alias ever resolves to more than one country** — inherently ambiguous forms ("Congo", "Korea") are excluded by construction.

## Size & impact

- `countries.min.json`: **+634 B** (36.4 → 37.0 KB). No CSV/SQL schema change (both use explicit fields; the only CSV/SQL diff is the Myanmar name fix).
- Non-breaking: `alias?` is optional; existing behaviour for current names is unchanged.

## Verified

`bun run ci` green — lint, all 3 typecheck targets, build, **21 tests** (incl. resolution + the ambiguity guard). Local CodeRabbit review clean. No generated `dist/` committed (rebuilt at release).

_Related: #35 (alternative names); #177 (4.0 size)._