### PR TITLE
Rename Nauru to Naoero

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "annexare/countries-list",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Continents & countries: ISO 3166-1 alpha-2 code, name, ISO 639-1 languages, capital, ISO 4217 currencies (symbols & numeric codes), native name, phone. JSON, CSV and SQL.",
   "type": "library",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "countries-workspace",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "workspaces": {
     "packages": [
       "packages/*"

--- a/packages/countries/package.json
+++ b/packages/countries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "countries",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -1567,8 +1567,9 @@ export const countries = {
     languages: ['ne'],
   },
   NR: {
-    name: 'Nauru',
-    native: 'Nauru',
+    name: 'Naoero',
+    native: 'Naoero',
+    alias: ['Nauru'],
     phone: [674],
     continent: 'OC',
     capital: 'Yaren',


### PR DESCRIPTION
<!--

  Thanks so much for your PR, your contribution is appreciated! ❤️

  Please check this:
  - unit tests are passing
  - separate changes with commits where necessary
  - when data needs to be changed, only files within `/data/` were modified
  - when there is an update for `package.json`, please also push `bun.lock` changes
  - no `/dist/` file changes accepted (they are built with every version bump)

 -->

Issue # <!-- Please specify if this PR closes an Issue, otherwise remove -->

Data changes verified with: https://apnews.com/article/naoero-nauru-name-change-pacific-island-6a25b916944dda6af7a0e619e004826b

While the article does mention that the ISO code is changing from `NRU` to `NRO` I couldn't find any publishing from the ISO agency itself about the change. Let me know if you'd like it updated anyway!
