### PR TITLE
Fix Caribbean Netherlands (BQ) country data in countries.ts

### DIFF
--- a/packages/countries/src/data/countries.ts
+++ b/packages/countries/src/data/countries.ts
@@ -280,13 +280,13 @@ export const countries = {
     languages: ['es', 'ay', 'qu'],
   },
   BQ: {
-    name: 'Bonaire',
-    native: 'Bonaire',
-    phone: [5997],
+    name: 'Bonaire, Sint Eustatius and Saba',
+    native: 'Bonaire, Sint Eustatius and Saba',
+    phone: [5993, 5994, 5997],
     continent: 'NA',
-    capital: 'Kralendijk',
+    capital: '',
     currency: ['USD'],
-    languages: ['nl'],
+    languages: ['nl', 'pa', 'en'],
   },
   BR: {
     name: 'Brazil',


### PR DESCRIPTION
# Fix Caribbean Netherlands (BQ) country data

<!--

  Thanks so much for your PR, your contribution is appreciated! ❤️

  Please check this:
  - unit tests are passing
  - separate changes with commits where necessary
  - when data needs to be changed, only files within `/data/` were modified
  - when there is an update for `package.json`, please also push `bun.lock` changes
  - no `/dist/` file changes accepted (they are built with every version bump)

 -->

Updates the `BQ` country record so it represents all three Caribbean Netherlands islands rather than Bonaire alone.

Changes:
- Updates the name from `Bonaire` to `Bonaire, Sint Eustatius and Saba`
- Adds the +599 prefixes for Sint Eustatius (`5993`), Saba (`5994`), and Bonaire (`5997`)
- Adds English and Papiamento alongside Dutch
- Removes Kralendijk as the capital because Kralendijk is specifically the capital of Bonaire, while BQ represents all three islands

Data changes verified with:

https://www.government.nl/faq/what-are-the-different-parts-of-the-kingdom-of-the-netherlands

https://www.ituob.org/issues/1188-en/